### PR TITLE
add one awesome operation!

### DIFF
--- a/rc-red.lua
+++ b/rc-red.lua
@@ -384,7 +384,7 @@ titlebar:init({ enable = true, exceptions = t_exceptions })
 
 -- Sloppy focus config
 --------------------------------------------------------------------------------
-local sloppy_focus_enabled = false
+local sloppy_focus_enabled = true
 
 local function catch_focus(c)
 	if awful.layout.get(c.screen) ~= awful.layout.suit.magnifier and awful.client.focus.filter(c) then

--- a/red/keys-config.lua
+++ b/red/keys-config.lua
@@ -61,6 +61,29 @@ local function kill_all()
 	end
 end
 
+local function minimize_all_else(c)
+    thisScreen = client.focus.screen
+    for _, cc in ipairs(client.get(c.screen)) do
+        if current(cc, thisScreen) and cc.window ~= c.window then
+                cc.minimized = true
+        end
+    end
+end
+
+local function has_minimized_one_else(c)
+    for _, cc in ipairs(client.get(c.screen)) do
+        if current(cc, client.focus.screen) and cc.minimized == true then
+            return true
+        end
+    end
+end
+
+local function restore_all_else(c)
+    for _, cc in ipairs(client.get(c.screen)) do
+        if current(cc, client.focus.screen) and cc.minimized then cc.minimized = false end
+    end
+end
+
 -- numeric key function
 local function naction(i, handler, is_tag)
 	return function ()
@@ -433,8 +456,14 @@ function hotkeys:init(args)
 		awful.button({                     }, 1, function (c) client.focus = c; c:raise() end),
 		awful.button({                     }, 2, redflat.service.mouse.move),
 		awful.button({ self.mod            }, 3, redflat.service.mouse.resize),
-		awful.button({                     }, 8, function(c) c:kill() end)
-	)
+                awful.button({                     }, 8, function(c) c:kill() end),
+                awful.button({ self.mod            }, 4, function (c) minimize_all_else(c) end),
+                awful.button({ self.mod            }, 5, function (c)
+                    if has_minimized_one_else(c) then
+                        restore_all_else(c)
+                    end
+                end
+                )
 
 
 	-- Hotkeys helper setup


### PR DESCRIPTION
self.mod + button4 (scroll up):  to minimize all the other clients with
current screen
self.mod + button5 (scroll down): to restore all the clients with
current screen

While using the transparent plus the awesome desktop widgets, it is
quite annoying while the transparent clients such as terminal on the
top of another client.

This is a counterpart of "self.mod + TAB", cause it minimized all
the other clients.