### PR TITLE
Fix y alignment for specific apps on maximize

### DIFF
--- a/colorless/titlebar-config.lua
+++ b/colorless/titlebar-config.lua
@@ -37,6 +37,7 @@ local function on_maximize(c)
 	local model = redtitle.get_model(c)
 	if model and not model.hidden then
 		c.height = c:geometry().height + (is_max and model.size or -model.size)
+		if is_max then c.y = c.screen.workarea.y end
 	end
 end
 


### PR DESCRIPTION
This is a little fix for the "dirty size correction" for clients where the size correction does not trigger a realignment of the client's coordinates, specifically their `y` coordinate.

This especially affects LibreOffice apps for me. When they are maximized, their size is corrected accordingly as the titlebar is cut off. But they are not realigned on the screen, meaning they are still located at `{ x = 0, y = <titlebar.height> }`. Thus there will be a gap at the top of the screen where the titlebar would normally be and the client window will overlap/bleed into the panel at the bottom because of the size increase.

Thus I added an explicit realignment for the `y` coordinate which is also multi-monitor compatible.