### PR TITLE
Add missing borders for unmaximized windows

### DIFF
--- a/colorless/signals-config.lua
+++ b/colorless/signals-config.lua
@@ -43,6 +43,16 @@ function signals:init(args)
 		end
 	)
 
+	-- add missing borders to windows that get unmaximized
+	client.connect_signal(
+		"property::maximized",
+		function(c)
+			if not c.maximized then
+				c.border_width = beautiful.border_width
+			end
+		end
+	)
+
 	-- enable sloppy focus, so that focus follows mouse
 	if env.sloppy_focus then
 		client.connect_signal("mouse::enter", do_sloppy_focus)


### PR DESCRIPTION
### This fixes the following issue:

Applications that start maximized have no `border_width` set.

### Steps to reproduce:

- open up an application
- set the window to maximized using the corresponding keybinding (e.g. `mod` + `m` for colorless)
- close the application while still maximized, so that Awesome will remember the maximized state
- open up the application again, it will start in maximized mode
- unmaximize the application
- the application has `border_width = 0` instead of `border_width = beautiful.border_width`