### PR TITLE
Prevent maximized client resize/move

### DIFF
--- a/colorless/signals-config.lua
+++ b/colorless/signals-config.lua
@@ -43,6 +43,19 @@ function signals:init(args)
 		end
 	)
 
+	-- don't let maximized windows move/resize themselves
+	client.connect_signal(
+		"request::geometry",
+		function(c)
+			if c.maximized then
+				c.height = c.screen.workarea.height - 2 * c.border_width
+				c.width = c.screen.workarea.width - 2 * c.border_width
+				c.x = c.screen.workarea.x
+				c.y = c.screen.workarea.y
+			end
+		end
+	)
+
 	-- enable sloppy focus, so that focus follows mouse
 	if env.sloppy_focus then
 		client.connect_signal("mouse::enter", do_sloppy_focus)


### PR DESCRIPTION
Some applications (especially GTK3 ones) allow you to move their window by dragging their toolbar or menubar. If in maximized state, this currently allows windows to be moved on their own. This change prevents such behavior.