### PR TITLE
Adjust volume widget to ruby theme

### DIFF
--- a/shade/ruby/rc-ruby.lua
+++ b/shade/ruby/rc-ruby.lua
@@ -137,7 +137,15 @@ tray.buttons = awful.util.table.join(
 -- PA volume control
 --------------------------------------------------------------------------------
 local volume = {}
-volume.widget = redflat.widget.pulse(nil, { widget = redflat.gauge.audio.blue.new })
+
+-- tricky custom style
+local volume_style = {
+    widget  = redflat.gauge.audio.blue.new,
+    audio   = beautiful.individual and beautiful.individual.volume_audio or {},
+}
+
+-- init widget
+volume.widget = redflat.widget.pulse(nil, volume_style)
 
 -- activate player widget
 redflat.float.player:init({ name = env.player })

--- a/themes/ruby/theme.lua
+++ b/themes/ruby/theme.lua
@@ -238,6 +238,9 @@ theme.individual.microphone_audio = {
 	icon    = theme.path .. "/widget/microphone.svg",
 	color   = { icon = theme.color.main, mute = theme.color.icon }
 }
+theme.individual.volume_audio = {
+    color   = { icon = theme.color.main, mute = theme.color.icon }
+}
 
 -- Floating widgets
 -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Volume widget was not following the color scheme for ruby (it was blue on muted and gray on active). This change makes it red when on (like the others widgets pattern) and gray when muted.